### PR TITLE
Fix CDN path for osmtogeojson

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
   (function(){
     const CDN={
       osmtogeojson:[
-        'https://unpkg.com/osmtogeojson@3/osmtogeojson.js',                    // ✅ unpkg (正パス)
-        'https://cdn.jsdelivr.net/npm/osmtogeojson@3/osmtogeojson.js',        // ✅ jsDelivr (正パス)
+        'https://unpkg.com/osmtogeojson@3.0.0-beta.5/osmtogeojson.js',        // ✅ unpkg (versioned)
+        'https://cdn.jsdelivr.net/npm/osmtogeojson@3.0.0-beta.5/osmtogeojson.js', // ✅ jsDelivr (versioned)
         'https://raw.githubusercontent.com/tyrasd/osmtogeojson/master/osmtogeojson.js' // GitHub Raw
       ]
     };


### PR DESCRIPTION
## Summary
- fix invalid CDN path for osmtogeojson by specifying version

## Testing
- `curl -s -o /dev/null -w "%{http_code}\n" https://unpkg.com/osmtogeojson@3.0.0-beta.5/osmtogeojson.js`
- `curl -s -o /dev/null -w "%{http_code}\n" https://cdn.jsdelivr.net/npm/osmtogeojson@3.0.0-beta.5/osmtogeojson.js`


------
https://chatgpt.com/codex/tasks/task_e_6869d95f2fa883268439f74b077806ad