### PR TITLE
Fix Overpass query with bbox and retry

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,17 +52,22 @@
     /**************** ここから地図ロジック ****************/
     function initMap(){
       const overpassURL='https://overpass-api.de/api/interpreter';
+      const bbox='[bbox:20,122,46,154]'; // Japan bounding box
       const style={4:{color:'#d7191c',weight:3,opacity:1},8:{color:'#2b83ba',weight:1.5,opacity:0.8},9:{color:'#1a9641',weight:1,opacity:0.8},10:{color:'#ff7f00',weight:0.8,opacity:0.8,dashArray:'3 3'}};
 
       const map=L.map('map').setView([36.5,138],5);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'© OpenStreetMap contributors'}).addTo(map);
 
       const layers={},labels={},loaded={},group=L.layerGroup().addTo(map);
-      async function fetchAdmin(lv){
+      async function fetchAdmin(lv,retry=0){
         const key=`osm_admin_${lv}_${new Date().toISOString().slice(0,10)}`;
         if(localStorage[key]) return JSON.parse(localStorage[key]);
-        const q=`[out:json][timeout:25];relation[admin_level=${lv}][boundary=administrative];(._;>;);out body;`;
+        const q=`[out:json][timeout:25]${bbox};relation[admin_level=${lv}][boundary=administrative];(._;>;);out body;`;
         const res=await fetch(overpassURL,{method:'POST',body:q,headers:{'Content-Type':'text/plain'}});
+        if(res.status===429 && retry<3){
+          await new Promise(ok=>setTimeout(ok,(retry+1)*1000));
+          return fetchAdmin(lv,retry+1);
+        }
         if(!res.ok) throw new Error('Overpass '+res.status);
         const geo=osmtogeojson(await res.json());
         localStorage[key]=JSON.stringify(geo); return geo;


### PR DESCRIPTION
## Summary
- limit Overpass query to Japan bounding box
- retry when the Overpass API responds with 429

## Testing
- `git show -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6869dafd94688326a383e969cccdfa94