### PR TITLE
Improve boundary layer loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,14 +80,37 @@
           loaded[lv]=true;
           layers[lv]=L.geoJSON(g,{style:style[lv],onEachFeature:(f,l)=>l.on({mouseover:e=>e.target.setStyle({weight:style[lv].weight+1,color:'#ffff00'}),mouseout:e=>e.target.setStyle(style[lv]),click:e=>L.popup().setLatLng(e.latlng).setContent(f.properties.tags.name||'').openOn(map)})}).addTo(group);
           labels[lv]=L.layerGroup(g.features.map(ft=>mkLabel(ft,lv)).filter(Boolean)).addTo(group);
-          if(lv===4) map.fitBounds(layers[4].getBounds());
+          const b=layers[lv].getBounds();
+          if(b.isValid()){
+            if(lv===4){
+              map.fitBounds(b);
+            }
+          }else{
+            console.warn('layer',lv,'has invalid bounds');
+          }
+          console.log('layer',lv,'loaded');
           refresh();
         }catch(err){
           console.error('layer',lv,err);
           loaded[lv]=false;
         }
       }
-      function refresh(){const z=map.getZoom();const vis={4:true,8:z>=8,9:z>=11,10:z>=13};[4,8,9,10].forEach(lv=>{if(!layers[lv])return;(vis[lv]?group.addLayer:group.removeLayer)(layers[lv]);(vis[lv]?group.addLayer:group.removeLayer)(labels[lv]);if(lv===8)layers[8].setStyle({opacity:z>=11?0.3:0.8});if(lv===9)layers[9].setStyle({opacity:z>=13?0.4:0.8});});}
+      function refresh(){
+        const z=map.getZoom();
+        const vis={4:true,8:z>=8,9:z>=11,10:z>=13};
+        [4,8,9,10].forEach(lv=>{
+          if(!layers[lv]) return;
+          if(vis[lv]){
+            group.addLayer(layers[lv]);
+            if(labels[lv]) group.addLayer(labels[lv]);
+          }else{
+            group.removeLayer(layers[lv]);
+            if(labels[lv]) group.removeLayer(labels[lv]);
+          }
+          if(lv===8) layers[8].setStyle({opacity:z>=11?0.3:0.8});
+          if(lv===9) layers[9].setStyle({opacity:z>=13?0.4:0.8});
+        });
+      }
       load(4);load(8);
       map.on('zoomend',async()=>{const z=map.getZoom();if(z>=11&&!layers[9])await load(9);if(z>=13&&!layers[10])await load(10);refresh();});
       let lbl=true;document.addEventListener('keydown',e=>{if(e.ctrlKey&&e.key.toLowerCase()==='l'){lbl=!lbl;Object.values(labels).forEach(lg=>lbl?group.addLayer(lg):group.removeLayer(lg));}});


### PR DESCRIPTION
## Summary
- handle invalid layer bounds gracefully
- avoid layer group errors and log when layers load

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869dcadce488326b5cf9264c7d87cbd